### PR TITLE
Correct text of "INSTALLED" label in Library/Boards Manager

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
@@ -59,7 +59,7 @@ export class ListItemRenderer<T extends ArduinoComponent> {
           className="installed"
           onClick={onClickUninstall}
           {...{
-            install: nls.localize('arduino/component/install', 'INSTALL'),
+            install: nls.localize('arduino/component/installed', 'INSTALLED'),
             uninstall: nls.localize('arduino/component/uninstall', 'Uninstall'),
           }}
         />

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -145,6 +145,7 @@
       "by": "by",
       "filterSearch": "Filter your search...",
       "install": "INSTALL",
+      "installed": "INSTALLED",
       "moreInfo": "More info",
       "uninstall": "Uninstall",
       "uninstallMsg": "Do you want to uninstall {0}?",


### PR DESCRIPTION
An "INSTALLED" label is shown on the items in the Library Manager and Boards Manager views that are currently installed on the user's system.

During some work to add missing internationalization to the UI strings, this text was changed to "INSTALL". That text is not appropriate for what this label is intended to communicate.

The regression is hereby corrected, while retaining the internationalization of the string.

### Motivation
<!-- Why this pull request? -->

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)