### PR TITLE
Update library dependency installation dialog response indexes

### DIFF
--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -139,12 +139,12 @@ export class LibraryListWidget extends ListWidget<
 
       if (result) {
         const { response } = result;
-        if (response === 0) {
-          // All
-          installDependencies = true;
-        } else if (response === 1) {
+        if (response === 1) {
           // Current only
           installDependencies = false;
+        } else if (response === 2) {
+          // All
+          installDependencies = true;
         }
       }
     } else {


### PR DESCRIPTION
Arduino libraries may specify dependencies on other libraries in their metadata. The installation of these dependencies is offered by the Arduino IDE when the user installs the dependent library using the Library Manager widget.

The order of the buttons in the dialog that offers the dependencies installation was recently rearranged. The dialog response interpretation code was not updated to reflect the changes to the button indexes at that time. This caused the "CANCEL" button to trigger the behavior expected from the "INSTALL ALL" button, and vice versa.

The indexes in the dialog response interpretation code is hereby updated to use the new button indexes.

### Motivation
<!-- Why this pull request? -->

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)